### PR TITLE
MS SQL doesn't support RegExps

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -20,6 +20,10 @@ function lt (q, table, el, obj, op) {
   return q[op](table[el].lt(obj['$lt']))
 }
 
+function like (q, table, el, obj, op) {
+  return q[op](table[el].like(obj['$like']))
+}
+
 function eq (q, table, el, obj, op, type) {
   if (type.isPrimitive) {
     return q[op](table[el].equals(obj))
@@ -75,6 +79,7 @@ var operations = {
   $lt: lt,
   $and: and,
   $or: or,
-  $in: inFn
+  $in: inFn,
+  $like: like
 }
 

--- a/lib/types/mssql.js
+++ b/lib/types/mssql.js
@@ -4,6 +4,6 @@ module.exports = {
   'Edm.Boolean': 'bit',
   'Edm.Int32': 'integer',
   'Edm.Int64': 'bigint',
-  'Edm.Float': 'float',
+  'Edm.Decimal': 'float',
   'Edm.Binary': 'varbinary(max)'
 }

--- a/lib/types/mssql.js
+++ b/lib/types/mssql.js
@@ -4,5 +4,6 @@ module.exports = {
   'Edm.Boolean': 'bit',
   'Edm.Int32': 'integer',
   'Edm.Int64': 'bigint',
+  'Edm.Float': 'float',
   'Edm.Binary': 'varbinary(max)'
 }


### PR DESCRIPTION
MS SQL doesn't support RegExps, so the idea was to have opportunity to have "like" options for odata functions contains, startswith and endswith.